### PR TITLE
Add CMake configuration for cTensor project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ Module.symvers
 Mkfile.old
 dkms.conf
 main
+
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+project(cTensor LANGUAGES C)
+
+# Include project headers
+include_directories(include)
+
+# Collect all source files
+file(GLOB_RECURSE SOURCES
+    "src/*.c"
+    "src2/*.c"
+)
+
+# Create executable
+add_executable(cten_exe ${SOURCES})
+
+# Set C standard
+set_target_properties(cten_exe PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+)
+
+# Link math library only on non-Windows systems
+if(NOT WIN32)
+    target_link_libraries(cten_exe PRIVATE m)
+endif()


### PR DESCRIPTION
First, we need to create a build folder. Inside the build folder, we require a build system to build the project and finally run the executable.

```bash
mkdir build
cd build
cmake ..
cmake --build .
```

### Linux/MacOS
```bash
./cten_exe
```

### Windows
If one wants to use the GNU C Compiler (MinGW), they should specify it while creating the build system and then build the project.

```
Remove-Item * -Recurse -Force
cmake .. -G "MinGW Makefiles" 
cmake --build .
```

*_For MSVC(C-compiler) skip above process_

```bash
./cten_exe.exe
```
