### PR TITLE
Fix broadcasting, cten_elementwise_broadcast

### DIFF
--- a/src/nn.c
+++ b/src/nn.c
@@ -39,13 +39,23 @@ Tensor nn_relu(Tensor self) {
 /* nn.softmax */
 static Tensor GradFn_softmax(Tensor self, int i) {
     Tensor input = self.node->inputs[i];
-    Tensor res = Tensor_new(input.shape, false);
-    for(int j = 0; j < input.data->numel; j++) {
-        float softmax_j = self.data->flex[j];
-        for(int k = 0; k < input.data->numel; k++) {
-            float softmax_k = self.data->flex[k];
-            float delta_jk = (j == k) ? 1.0f : 0.0f;
-            res.data->flex[j * input.data->numel + k] = softmax_j * (delta_jk - softmax_k);
+    int num_classes = input.shape[TensorShape_dim(input.shape) - 1]; 
+    int batch_size = input.data->numel / num_classes;
+
+    Tensor res = Tensor_zeros(input.shape, false);
+
+    for (int batch = 0; batch < batch_size; batch++) {
+        float grad_sum = 0.0f;
+
+        for (int k = 0; k < num_classes; k++) {
+            grad_sum += self.data->flex[batch * num_classes + k] * self.node->grad.data->flex[batch * num_classes + k];
+        }
+
+        for (int j = 0; j < num_classes; j++) {
+            float softmax_j = self.data->flex[batch * num_classes + j];
+            float grad_j = self.node->grad.data->flex[batch * num_classes + j];
+
+            res.data->flex[batch * num_classes + j] = softmax_j * (grad_j - grad_sum);
         }
     }
     return res;
@@ -88,6 +98,27 @@ Tensor nn_softmax(Tensor self) {
     return res;
 }
 
+Tensor GradFn_crossentropy(Tensor self, int i) {
+    Tensor y_true = self.node->inputs[0];
+    Tensor y_pred = self.node->inputs[1];
+
+    Tensor grad = Tensor_zeros(y_pred.shape, false);
+
+    if (i == 1) {
+        // f'(y_true, y_pred) = -y_true / y_pred
+        int n_samples = y_pred.shape[0];
+        int n_classes = y_pred.shape[1];
+
+        for (int s = 0; s < n_samples; s++) {
+            for (int c = 0; c < n_classes; c++) {
+                int idx = s * n_classes + c;
+                grad.data->flex[idx] = -y_true.data->flex[idx] / y_pred.data->flex[idx];
+            }
+        }
+    }
+    return grad;
+}
+
 /* nn.cross_entropy */
 Tensor nn_crossentropy(Tensor y_true, Tensor y_pred) {
     // y_true: [None, n_classes]
@@ -101,7 +132,7 @@ Tensor nn_crossentropy(Tensor y_true, Tensor y_pred) {
     assert(n_classes == y_pred.shape[1]);
 
     bool requires_grad = !cten_is_eval() && (y_true.node != NULL || y_pred.node != NULL);
-    Tensor res = Tensor_new((TensorShape){n_samples}, requires_grad);
+    Tensor res = Tensor_new((TensorShape){n_samples, 1}, requires_grad);
     for(int i = 0; i < n_samples; i++) {
         float loss = 0;
         for(int j = 0; j < n_classes; j++) {
@@ -109,6 +140,13 @@ Tensor nn_crossentropy(Tensor y_true, Tensor y_pred) {
                 y_true.data->flex[i * n_classes + j] * logf(y_pred.data->flex[i * n_classes + j]);
         }
         res.data->flex[i] = -loss;
+    }
+
+    if (requires_grad) {
+        res.node->grad_fn = GradFn_crossentropy;
+        res.node->inputs[0] = y_true;
+        res.node->inputs[1] = y_pred;
+        res.node->n_inputs = 2;
     }
     return Tensor_mean(res);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,46 +33,66 @@ void cten_assert_dim(const char* title, int a, int b) {
 bool cten_elemwise_broadcast(Tensor* a, Tensor* b) {
     int a_dim = TensorShape_dim(a->shape);
     int b_dim = TensorShape_dim(b->shape);
-    if(a_dim != b_dim) return false;
+
+    if (a_dim != b_dim) return false;
+
     int a_broadcast = -1;
-    for(int i = 0; i < a_dim; i++) {
-        if(a->shape[i] == b->shape[i]) continue;
-        if(a->shape[i] == 1) {
-            if(a_broadcast == 0) return false;
+
+    for (int i = 0; i < a_dim; i++) {
+        if (a->shape[i] == b->shape[i]) continue;
+        if (a->shape[i] == 1) {
+            if (a_broadcast == 0) return false;
             a_broadcast = 1;
-        } else if(b->shape[i] == 1) {
-            if(a_broadcast == 1) return false;
+        } else if (b->shape[i] == 1) {
+            if (a_broadcast == 1) return false;
             a_broadcast = 0;
         } else {
             return false;
         }
     }
-    if(a_broadcast != -1) {
-        if(a_broadcast == 0) {
+
+    if (a_broadcast != -1) {
+        if (a_broadcast == 0) { 
             Tensor* tmp = a;
             a = b;
             b = tmp;
             a_broadcast = 1;
         }
-        Tensor a_ = Tensor_new(b->shape, a->node != NULL);
-        for(int i = 0; i < a_.shape[0]; i++) {
-            int i_ = a->shape[0] == 1 ? 0 : i;
-            for(int j = 0; j < a_.shape[1]; j++) {
-                int j_ = a->shape[1] == 1 ? 0 : j;
-                for(int k = 0; k < a_.shape[2]; k++) {
-                    int k_ = a->shape[2] == 1 ? 0 : k;
-                    for(int l = 0; l < a_.shape[3]; l++) {
-                        int l_ = a->shape[3] == 1 ? 0 : l;
-                        // a_[i][j][k][l] = a[i_][j_][k_][l_]
-                        a_.data->flex[i * a_.shape[1] * a_.shape[2] * a_.shape[3] +
-                                      j * a_.shape[2] * a_.shape[3] + k * a_.shape[3] + l] =
-                            a->data->flex[i_ * a->shape[1] * a->shape[2] * a->shape[3] +
-                                          j_ * a->shape[2] * a->shape[3] + k_ * a->shape[3] + l_];
+
+        Tensor a_ = Tensor_zeros(b->shape, a->node != NULL);
+
+        int stride_a_1 = (a_dim > 1) ? a->shape[1] : 1;
+        int stride_a_2 = (a_dim > 2) ? a->shape[2] : 1;
+        int stride_a_3 = (a_dim > 3) ? a->shape[3] : 1;
+
+        int stride_a_1_new = (a_dim > 1) ? a_.shape[1] : 1;
+        int stride_a_2_new = (a_dim > 2) ? a_.shape[2] : 1;
+        int stride_a_3_new = (a_dim > 3) ? a_.shape[3] : 1;
+
+        for (int i = 0; i < a_.shape[0]; i++) {
+            int i_ = (a->shape[0] == 1) ? 0 : i;
+            for (int j = 0; j < ((a_dim > 1) ? a_.shape[1] : 1); j++) {
+                int j_ = (a_dim > 1 && a->shape[1] == 1) ? 0 : j;
+                for (int k = 0; k < ((a_dim > 2) ? a_.shape[2] : 1); k++) {
+                    int k_ = (a_dim > 2 && a->shape[2] == 1) ? 0 : k;
+                    for (int l = 0; l < ((a_dim > 3) ? a_.shape[3] : 1); l++) {
+                        int l_ = (a_dim > 3 && a->shape[3] == 1) ? 0 : l;
+
+                        int dst_idx = i * stride_a_1_new * stride_a_2_new * stride_a_3_new +
+                                      j * stride_a_2_new * stride_a_3_new +
+                                      k * stride_a_3_new + l;
+
+                        int src_idx = i_ * stride_a_1 * stride_a_2 * stride_a_3 +
+                                      j_ * stride_a_2 * stride_a_3 +
+                                      k_ * stride_a_3 + l_;
+
+                        a_.data->flex[dst_idx] = a->data->flex[src_idx];
                     }
                 }
             }
         }
         *a = a_;
     }
+
     return true;
 }


### PR DESCRIPTION
**Issue:**
Currently, `cten_elementwise_broadcast` doesn't actually broadcast unless the tensors are 4D. It creates a tensor of right shape but doesn't replicate the values.

```
    for(int i = 0; i < a_.shape[0]; i++) {
            int i_ = a->shape[0] == 1 ? 0 : i;
            for(int j = 0; j < a_.shape[1]; j++) {
                int j_ = a->shape[1] == 1 ? 0 : j;
                for(int k = 0; k < a_.shape[2]; k++) {
                    int k_ = a->shape[2] == 1 ? 0 : k;
                    for(int l = 0; l < a_.shape[3]; l++) {
                       ..... 

```

when the tensors are of lower dimensions, the loop condition fails if shape[i] is zero, so it never replicates the values and instead returns of a new tensor of broadcasted shape.