### PR TITLE
[Feat] : Add backward pass for sub, relu, and linear ops

### DIFF
--- a/src/operator.c
+++ b/src/operator.c
@@ -404,18 +404,20 @@ Tensor Tensor_pow(Tensor self, Tensor other) {
 }
 
 Tensor Tensor_sub(Tensor self, Tensor other) {
+    Tensor orig_self = self;
+    Tensor orig_other = other;
     if (!cten_elemwise_broadcast(&self, &other)) {
-        cten_assert_shape("Tensor_sub() cannot broadcast", self.shape, other.shape);
+        cten_assert_shape("Tensor_sub() cannot broadcast", orig_self.shape, orig_other.shape);
     }
-    bool requires_grad = !cten_is_eval() && (self.node != NULL || other.node != NULL);
+    bool requires_grad = !cten_is_eval() && (orig_self.node != NULL || orig_other.node != NULL);
     Tensor res = Tensor_new(self.shape, requires_grad);
     for (int i = 0; i < self.data->numel; i++) {
         res.data->flex[i] = self.data->flex[i] - other.data->flex[i];
     }
     if (requires_grad) {
-        res.node->grad_fn = GradFn_sub; // Define GradFn_sub if needed
-        res.node->inputs[0] = self;
-        res.node->inputs[1] = other;
+        res.node->grad_fn = GradFn_sub;
+        res.node->inputs[0] = orig_self;
+        res.node->inputs[1] = orig_other;
         res.node->n_inputs = 2;
         res.node->name = "Sub";
     }

--- a/tests/Backward/test_linear_backward.c
+++ b/tests/Backward/test_linear_backward.c
@@ -1,0 +1,228 @@
+#include "../../include/cten.h"
+#include "../test_utils.h"
+#include "../csv_reporter.h"
+#include "../test_config.h"
+#include <stdio.h>
+
+void test_linear_backward() {
+    const char* op_name = "linear_backward";
+    PoolId pool_id = 0; 
+    cten_begin_malloc(pool_id);
+
+    // Test Case 1: Simple linear backward
+    {
+        const char* tc_name = "Simple_linear_backward";
+        // Sub-test 1: Basic linear layer
+        {
+            TensorShape input_shape = {1, 3};  // batch_size=1, input_features=3
+            TensorShape weight_shape = {3, 2};  // input_features=3, output_features=2
+            TensorShape bias_shape = {1, 2};    // output_features=2
+            
+            float input_data[] = {1.0f, 2.0f, 3.0f};
+            float weight_data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+            float bias_data[] = {0.1f, 0.2f};
+            
+            // Expected gradients
+            float exp_grad_input[] = {0.3f, 0.7f, 1.1f};  // input_grad = weight.T @ grad_output
+            float exp_grad_weight[] = {1.0f, 2.0f, 3.0f, 1.0f, 2.0f, 3.0f};  // weight_grad = input.T @ grad_output
+            float exp_grad_bias[] = {1.0f, 1.0f};  // bias_grad = sum(grad_output, dim=0)
+            
+            Tensor input = create_test_tensor(input_shape, input_data, true);
+            Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+            Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+            Tensor output = nn_linear(input, weight, bias);
+            
+            // Create a gradient for the output
+            TensorShape grad_shape = {1, 2};  // Same as output shape
+            float grad_data[] = {1.0f, 1.0f};
+            Tensor grad_output = create_test_tensor(grad_shape, grad_data, false);
+            
+            Tensor_backward(output, grad_output);
+            
+            Tensor expected_grad_input = create_test_tensor(input_shape, exp_grad_input, false);
+            Tensor expected_grad_weight = create_test_tensor(weight_shape, exp_grad_weight, false);
+            Tensor expected_grad_bias = create_test_tensor(bias_shape, exp_grad_bias, false);
+
+            compare_tensors(&input.node->grad, &expected_grad_input, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&weight.node->grad, &expected_grad_weight, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&bias.node->grad, &expected_grad_bias, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 2: Batch input linear backward
+    {
+        const char* tc_name = "Batch_linear_backward";
+        // Sub-test 1: Batch size > 1
+        {
+            TensorShape input_shape = {2, 3};  // batch_size=2, input_features=3
+            TensorShape weight_shape = {3, 2};  // input_features=3, output_features=2
+            TensorShape bias_shape = {1, 2};    // output_features=2
+            
+            float input_data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            float weight_data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+            float bias_data[] = {0.1f, 0.2f};
+            
+            // Expected gradients
+            float exp_grad_input[] = {0.3f, 0.7f, 1.1f, 0.3f, 0.7f, 1.1f};
+            float exp_grad_weight[] = {5.0f, 7.0f, 9.0f, 5.0f, 7.0f, 9.0f};
+            float exp_grad_bias[] = {2.0f, 2.0f};  // Sum over batch dimension
+            
+            Tensor input = create_test_tensor(input_shape, input_data, true);
+            Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+            Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+            Tensor output = nn_linear(input, weight, bias);
+            
+            // Create a gradient for the output
+            TensorShape grad_shape = {2, 2};  // Same as output shape
+            float grad_data[] = {1.0f, 1.0f, 1.0f, 1.0f};
+            Tensor grad_output = create_test_tensor(grad_shape, grad_data, false);
+            
+            Tensor_backward(output, grad_output);
+            
+            Tensor expected_grad_input = create_test_tensor(input_shape, exp_grad_input, false);
+            Tensor expected_grad_weight = create_test_tensor(weight_shape, exp_grad_weight, false);
+            Tensor expected_grad_bias = create_test_tensor(bias_shape, exp_grad_bias, false);
+
+            compare_tensors(&input.node->grad, &expected_grad_input, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&weight.node->grad, &expected_grad_weight, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&bias.node->grad, &expected_grad_bias, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 3: Random input linear backward
+    {
+        const char* tc_name = "Random_input_linear_backward";
+        // Sub-test 1: Random input values
+        {
+            TensorShape input_shape = {2, 4};  // batch_size=2, input_features=4
+            TensorShape weight_shape = {4, 3};  // input_features=4, output_features=3
+            TensorShape bias_shape = {1, 3};    // output_features=3
+            
+            float input_data[] = {0.5f, 1.3f, 2.7f, 0.8f, 1.9f, 0.4f, 1.2f, 3.1f};
+            float weight_data[] = {0.2f, 0.1f, 0.3f, 0.5f, 0.4f, 0.2f, 0.1f, 0.7f, 0.6f, 0.3f, 0.2f, 0.8f};
+            float bias_data[] = {0.5f, 0.3f, 0.2f};
+            
+            // Expected gradients for a gradient of ones at the output
+            float exp_grad_bias[] = {2.0f, 2.0f, 2.0f};  // Sum over batch dimension
+            
+            Tensor input = create_test_tensor(input_shape, input_data, true);
+            Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+            Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+            Tensor output = nn_linear(input, weight, bias);
+            
+            // Create a gradient for the output
+            TensorShape grad_shape = {2, 3};  // Same as output shape
+            float grad_data[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+            Tensor grad_output = create_test_tensor(grad_shape, grad_data, false);
+            
+            Tensor_backward(output, grad_output);
+            
+            Tensor expected_grad_bias = create_test_tensor(bias_shape, exp_grad_bias, false);
+
+            // Focus on bias gradient
+            compare_tensors(&bias.node->grad, &expected_grad_bias, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Different gradient values
+        {
+            TensorShape input_shape = {3, 2};  // batch_size=3, input_features=2
+            TensorShape weight_shape = {2, 4};  // input_features=2, output_features=4
+            TensorShape bias_shape = {1, 4};    // output_features=4
+            
+            float input_data[] = {1.5f, 2.3f, 0.7f, 1.8f, 3.2f, 0.9f};
+            float weight_data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f};
+            float bias_data[] = {0.1f, 0.2f, 0.3f, 0.4f};
+            
+            // Create a non-uniform gradient for the output
+            TensorShape grad_shape = {3, 4};  // Same as output shape
+            float grad_data[] = {
+                0.5f, 1.0f, 1.5f, 2.0f,
+                0.1f, 0.2f, 0.3f, 0.4f,
+                1.0f, 0.8f, 0.6f, 0.4f
+            };
+            
+            // Expected bias gradient is the sum of the output gradient across the batch dimension
+            float exp_grad_bias[] = {1.6f, 2.0f, 2.4f, 2.8f};
+            
+            Tensor input = create_test_tensor(input_shape, input_data, true);
+            Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+            Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+            Tensor output = nn_linear(input, weight, bias);
+            Tensor grad_output = create_test_tensor(grad_shape, grad_data, false);
+            
+            Tensor_backward(output, grad_output);
+            
+            Tensor expected_grad_bias = create_test_tensor(bias_shape, exp_grad_bias, false);
+
+            // Focus on bias gradient
+            compare_tensors(&bias.node->grad, &expected_grad_bias, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // TODO: Tensor_sum and Tensor_mean backward is in working progress
+    // // Test Case 4: Chained operations with linear
+    // {
+    //     const char* tc_name = "Chained_operations_with_linear";
+    //     // Sub-test 1: Linear followed by sum
+    //     {
+    //         TensorShape input_shape = {2, 3};  // batch_size=2, input_features=3
+    //         TensorShape weight_shape = {3, 2};  // input_features=3, output_features=2
+    //         TensorShape bias_shape = {1, 2};    // output_features=2
+            
+    //         float input_data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    //         float weight_data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+    //         float bias_data[] = {0.1f, 0.2f};
+            
+    //         // Expected gradients
+    //         float exp_grad_bias[] = {1.0f, 1.0f};  // For sum reduction
+            
+    //         Tensor input = create_test_tensor(input_shape, input_data, true);
+    //         Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+    //         Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+    //         Tensor output = nn_linear(input, weight, bias);
+    //         Tensor sum_output = Tensor_sum(output);
+            
+    //         Tensor_backward(sum_output, (Tensor){0});
+            
+    //         Tensor expected_grad_bias = create_test_tensor(bias_shape, exp_grad_bias, false);
+
+    //         // Focus on bias gradient
+    //         compare_tensors(&bias.node->grad, &expected_grad_bias, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 2: Linear followed by mean
+    //     {
+    //         TensorShape input_shape = {2, 3};  // batch_size=2, input_features=3
+    //         TensorShape weight_shape = {3, 2};  // input_features=3, output_features=2
+    //         TensorShape bias_shape = {1, 2};    // output_features=2
+            
+    //         float input_data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    //         float weight_data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+    //         float bias_data[] = {0.1f, 0.2f};
+            
+    //         // Expected gradients
+    //         float exp_grad_bias[] = {0.25f, 0.25f};  // For mean reduction (1/4)
+            
+    //         Tensor input = create_test_tensor(input_shape, input_data, true);
+    //         Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+    //         Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+    //         Tensor output = nn_linear(input, weight, bias);
+    //         Tensor mean_output = Tensor_mean(output);
+            
+    //         Tensor_backward(mean_output, (Tensor){0});
+            
+    //         Tensor expected_grad_bias = create_test_tensor(bias_shape, exp_grad_bias, false);
+
+    //         // Focus on bias gradient
+    //         compare_tensors(&bias.node->grad, &expected_grad_bias, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+    //     }
+    // }
+
+    cten_free(pool_id);
+}

--- a/tests/Backward/test_relu_backward.c
+++ b/tests/Backward/test_relu_backward.c
@@ -1,0 +1,200 @@
+#include "../../include/cten.h"
+#include "../test_utils.h"
+#include "../csv_reporter.h"
+#include "../test_config.h"
+#include <stdio.h>
+
+void test_relu_backward() {
+    const char* op_name = "relu_backward";
+    PoolId pool_id = 0; 
+    cten_begin_malloc(pool_id);
+
+    // Test Case 1: Simple ReLU backward
+    {
+        const char* tc_name = "Simple_relu_backward";
+        // Sub-test 1: Scalar ReLU
+        {
+            TensorShape s_shape = {1};
+            float d1[] = {2.0f};  // Positive value
+            float exp_grad1[] = {1.0f};  // Gradient passes through for positive values
+            
+            Tensor t1 = create_test_tensor(s_shape, d1, true);
+            Tensor z = nn_relu(t1);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(s_shape, exp_grad1, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Scalar ReLU with negative input
+        {
+            TensorShape s_shape = {1};
+            float d1[] = {-2.0f};  // Negative value
+            float exp_grad1[] = {0.0f};  // Gradient is zero for negative values
+            
+            Tensor t1 = create_test_tensor(s_shape, d1, true);
+            Tensor z = nn_relu(t1);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(s_shape, exp_grad1, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 3: Vector ReLU
+        {
+            TensorShape v_shape = {4};
+            float d1[] = {-1.0f, 0.0f, 1.0f, 2.0f};
+            float exp_grad1[] = {0.0f, 0.0f, 1.0f, 1.0f};  // Gradient is 0 for x <= 0, 1 for x > 0
+            
+            Tensor t1 = create_test_tensor(v_shape, d1, true);
+            Tensor z = nn_relu(t1);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(v_shape, exp_grad1, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 2: Matrix ReLU backward
+    {
+        const char* tc_name = "Matrix_relu_backward";
+        // Sub-test 1: Matrix with mixed values
+        {
+            TensorShape m_shape = {2, 3};
+            float data[] = {-1.0f, 0.0f, 1.0f, 2.0f, -3.0f, 4.0f};
+            float exp_grad[] = {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
+            
+            Tensor t = create_test_tensor(m_shape, data, true);
+            Tensor z = nn_relu(t);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad = create_test_tensor(m_shape, exp_grad, false);
+
+            compare_tensors(&t.node->grad, &expected_grad, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 3: More ReLU backward
+    {
+        const char* tc_name = "More_relu_backward";
+        // Sub-test 1: Random values
+        {
+            TensorShape v_shape = {6};
+            float data[] = {-2.5f, 1.3f, 0.0f, -0.7f, 3.2f, -1.8f};
+            float exp_grad[] = {0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f};
+            
+            Tensor t = create_test_tensor(v_shape, data, true);
+            Tensor z = nn_relu(t);
+            Tensor l = Tensor_sum(z);            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad = create_test_tensor(v_shape, exp_grad, false);
+
+            compare_tensors(&t.node->grad, &expected_grad, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: 3D tensor with random values
+        {
+            TensorShape tensor3d_shape = {2, 2, 2};
+            float data[] = {-1.5f, 2.7f, 0.0f, -3.1f, 4.2f, -0.8f, 1.9f, 0.0f};
+            float exp_grad[] = {0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f};
+            
+            Tensor t = create_test_tensor(tensor3d_shape, data, true);
+            Tensor z = nn_relu(t);
+            Tensor l = Tensor_sum(z);            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad = create_test_tensor(tensor3d_shape, exp_grad, false);
+
+            compare_tensors(&t.node->grad, &expected_grad, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 4: Custom gradient ReLU backward
+    {
+        const char* tc_name = "Custom_gradient_relu_backward";
+        // Sub-test 1: Non-uniform gradient
+        {
+            TensorShape v_shape = {4};
+            float data[] = {-1.0f, 0.0f, 1.0f, 2.0f};
+            float grad_data[] = {0.5f, 1.0f, 1.5f, 2.0f};
+            float exp_grad[] = {0.0f, 0.0f, 1.5f, 2.0f};  // Element-wise product of input gradient and ReLU derivative
+            
+            Tensor t = create_test_tensor(v_shape, data, true);
+            Tensor z = nn_relu(t);
+            Tensor l = Tensor_sum(z);            
+            TensorShape grad_shape = {4};
+            Tensor grad = create_test_tensor(grad_shape, grad_data, false);
+            
+            Tensor_backward(l, grad);
+            
+            Tensor expected_grad = create_test_tensor(v_shape, exp_grad, false);
+
+            compare_tensors(&t.node->grad, &expected_grad, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 5: Chained operations with ReLU
+    {
+        const char* tc_name = "Chained_operations_with_relu";
+        // Sub-test 1: Linear -> ReLU -> Sum
+        {
+            TensorShape input_shape = {2, 3};
+            TensorShape weight_shape = {3, 4};
+            TensorShape bias_shape = {1, 4};
+            
+            float input_data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            float weight_data[] = {0.1f, -0.2f, 0.3f, 0.4f, 0.5f, -0.6f, 0.7f, -0.8f, 0.9f, 1.0f, -1.1f, 1.2f};
+            float bias_data[] = {0.1f, -0.1f, 0.2f, -0.2f};
+            
+            Tensor input = create_test_tensor(input_shape, input_data, true);
+            Tensor weight = create_test_tensor(weight_shape, weight_data, true);
+            Tensor bias = create_test_tensor(bias_shape, bias_data, true);
+            
+            Tensor linear_output = nn_linear(input, weight, bias);
+            Tensor relu_output = nn_relu(linear_output);
+            Tensor sum_output = Tensor_sum(relu_output);
+            
+            Tensor_backward(sum_output, (Tensor){0});
+            
+            // We're not checking specific values here, just that the backward pass completes
+            // and the gradients are computed correctly through the chain
+            
+            // Verify that gradients exist for all tensors in the chain
+            if (input.node->grad.data == NULL || weight.node->grad.data == NULL || bias.node->grad.data == NULL) {
+                printf("Error: Gradients not computed for all tensors in the chain\n");
+            }
+        }
+
+        // TODO: Mean Backward is in working progress
+        // // Sub-test 2: ReLU -> Mean with mixed values
+        // {
+        //     TensorShape m_shape = {2, 3};
+        //     float data[] = {-1.0f, 0.0f, 1.0f, 2.0f, -3.0f, 4.0f};
+        //     float exp_grad[] = {0.0f, 0.0f, 1.0f/6.0f, 1.0f/6.0f, 0.0f, 1.0f/6.0f};  // 1/6 for positive values, 0 for negative
+            
+        //     Tensor t = create_test_tensor(m_shape, data, true);
+        //     Tensor relu_output = nn_relu(t);
+        //     Tensor mean_output = Tensor_mean(relu_output);
+            
+        //     Tensor_backward(mean_output, (Tensor){0});
+            
+        //     Tensor expected_grad = create_test_tensor(m_shape, exp_grad, false);
+
+        //     compare_tensors(&t.node->grad, &expected_grad, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        // }
+    }
+
+    cten_free(pool_id);
+}

--- a/tests/Backward/test_sub_backward.c
+++ b/tests/Backward/test_sub_backward.c
@@ -1,0 +1,236 @@
+#include "../../include/cten.h"
+#include "../test_utils.h"
+#include "../csv_reporter.h"
+#include "../test_config.h"
+#include <stdio.h>
+
+void test_sub_backward() {
+    const char* op_name = "sub_backward";
+    PoolId pool_id = 0; 
+    cten_begin_malloc(pool_id);
+
+    // Test Case 1: Simple backward (1x1 tensors)
+    {
+        const char* tc_name = "Simple_backward";
+        // Sub-test 1: Scalar backward
+        {
+            TensorShape s_shape = {1};
+            float d1[] = {5.0f};
+            float d2[] = {3.0f};
+            float exp_grad1[] = {1.0f};  // dz/dx = 1
+            float exp_grad2[] = {-1.0f}; // dz/dy = -1
+            
+            Tensor t1 = create_test_tensor(s_shape, d1, true);
+            Tensor t2 = create_test_tensor(s_shape, d2, true);
+            Tensor z = Tensor_sub(t1, t2);  // z = 2.0
+            
+            Tensor_backward(z, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(s_shape, exp_grad1, false);
+            Tensor expected_grad2 = create_test_tensor(s_shape, exp_grad2, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t2.node->grad, &expected_grad2, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Vector sub backward
+        {
+            TensorShape v_shape = {3};
+            float d1[] = {5.0f, 7.0f, 9.0f};
+            float d2[] = {2.0f, 3.0f, 4.0f};
+            float exp_grad1[] = {1.0f, 1.0f, 1.0f};
+            float exp_grad2[] = {-1.0f, -1.0f, -1.0f};
+            
+            Tensor t1 = create_test_tensor(v_shape, d1, true);
+            Tensor t2 = create_test_tensor(v_shape, d2, true);
+            Tensor z = Tensor_sub(t1, t2);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(v_shape, exp_grad1, false);
+            Tensor expected_grad2 = create_test_tensor(v_shape, exp_grad2, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t2.node->grad, &expected_grad2, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 3: Matrix sub backward
+        {
+            TensorShape m_shape = {2, 2};
+            float d1[] = {10.0f, 20.0f, 30.0f, 40.0f};
+            float d2[] = {1.0f, 2.0f, 3.0f, 4.0f};
+            float exp_grad1[] = {1.0f, 1.0f, 1.0f, 1.0f};
+            float exp_grad2[] = {-1.0f, -1.0f, -1.0f, -1.0f};
+            
+            Tensor t1 = create_test_tensor(m_shape, d1, true);
+            Tensor t2 = create_test_tensor(m_shape, d2, true);
+            Tensor z = Tensor_sub(t1, t2);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(m_shape, exp_grad1, false);
+            Tensor expected_grad2 = create_test_tensor(m_shape, exp_grad2, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t2.node->grad, &expected_grad2, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 2: Broadcasting backward
+    {
+        const char* tc_name = "Broadcasting_backward";
+        // Sub-test 1: Vector - Scalar
+        {
+            TensorShape vec_shape = {2};
+            TensorShape scalar_shape = {1};
+            float vec_data[] = {5.0f, 10.0f};
+            float scalar_data[] = {3.0f};
+            float exp_grad_vec[] = {1.0f, 1.0f};
+            float exp_grad_scalar[] = {-2.0f};
+            
+            Tensor t_vec = create_test_tensor(vec_shape, vec_data, true);
+            Tensor t_scalar = create_test_tensor(scalar_shape, scalar_data, true);
+            Tensor z = Tensor_sub(t_vec, t_scalar);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad_vec = create_test_tensor(vec_shape, exp_grad_vec, false);
+            Tensor expected_grad_scalar = create_test_tensor(scalar_shape, exp_grad_scalar, false);
+
+            compare_tensors(&t_vec.node->grad, &expected_grad_vec, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t_scalar.node->grad, &expected_grad_scalar, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Matrix - Row Vector
+        {
+            TensorShape mat_shape = {2, 3};
+            TensorShape row_shape = {1, 3};
+            float mat_data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            float row_data[] = {0.1f, 0.2f, 0.3f};
+            float exp_grad_mat[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+            float exp_grad_row[] = {-2.0f, -2.0f, -2.0f};
+
+            Tensor t_mat = create_test_tensor(mat_shape, mat_data, true);
+            Tensor t_row = create_test_tensor(row_shape, row_data, true);
+            Tensor z = Tensor_sub(t_mat, t_row);
+            Tensor l = Tensor_sum(z);
+
+            Tensor_backward(l, (Tensor){0});
+
+            Tensor expected_grad_mat = create_test_tensor(mat_shape, exp_grad_mat, false);
+            Tensor expected_grad_row = create_test_tensor(row_shape, exp_grad_row, false);
+
+            compare_tensors(&t_mat.node->grad, &expected_grad_mat, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t_row.node->grad, &expected_grad_row, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 3: Matrix - Column Vector
+        {
+            TensorShape mat_shape = {2, 3};
+            TensorShape col_shape = {2, 1};
+            float mat_data[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            float col_data[] = {10.0f, 20.0f};
+            float exp_grad_mat[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+            float exp_grad_col[] = {-3.0f, -3.0f};
+
+            Tensor t_mat = create_test_tensor(mat_shape, mat_data, true);
+            Tensor t_col = create_test_tensor(col_shape, col_data, true);
+            Tensor z = Tensor_sub(t_mat, t_col);
+            Tensor l = Tensor_sum(z);
+
+            Tensor_backward(l, (Tensor){0});
+
+            Tensor expected_grad_mat = create_test_tensor(mat_shape, exp_grad_mat, false);
+            Tensor expected_grad_col = create_test_tensor(col_shape, exp_grad_col, false);
+
+            compare_tensors(&t_mat.node->grad, &expected_grad_mat, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t_col.node->grad, &expected_grad_col, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 3: Random input backward
+    {
+        const char* tc_name = "Random_input_backward";
+        // Sub-test 1: Random vector subtraction
+        {
+            TensorShape v_shape = {4};
+            float d1[] = {2.5f, 3.7f, 1.2f, 8.9f};
+            float d2[] = {1.1f, 2.2f, 0.5f, 3.3f};
+            float exp_grad1[] = {1.0f, 1.0f, 1.0f, 1.0f};
+            float exp_grad2[] = {-1.0f, -1.0f, -1.0f, -1.0f};
+            
+            Tensor t1 = create_test_tensor(v_shape, d1, true);
+            Tensor t2 = create_test_tensor(v_shape, d2, true);
+            Tensor z = Tensor_sub(t1, t2);
+            Tensor l = Tensor_sum(z);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad1 = create_test_tensor(v_shape, exp_grad1, false);
+            Tensor expected_grad2 = create_test_tensor(v_shape, exp_grad2, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t2.node->grad, &expected_grad2, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Random 3D tensor subtraction
+        {
+            TensorShape tensor3d_shape = {2, 2, 2};
+            float data1[] = {1.5f, 2.7f, 3.1f, 4.2f, 5.3f, 6.8f, 7.4f, 8.0f};
+            float data2[] = {0.5f, 0.7f, 0.9f, 1.2f, 1.3f, 1.8f, 1.4f, 2.0f};
+            float exp_grad1[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+            float exp_grad2[] = {-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
+
+            Tensor t1 = create_test_tensor(tensor3d_shape, data1, true);
+            Tensor t2 = create_test_tensor(tensor3d_shape, data2, true);
+            Tensor z = Tensor_sub(t1, t2);
+            Tensor l = Tensor_sum(z);
+
+            Tensor_backward(l, (Tensor){0});
+
+            Tensor expected_grad1 = create_test_tensor(tensor3d_shape, exp_grad1, false);
+            Tensor expected_grad2 = create_test_tensor(tensor3d_shape, exp_grad2, false);
+
+            compare_tensors(&t1.node->grad, &expected_grad1, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&t2.node->grad, &expected_grad2, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 4: Chained operations
+    {
+        const char* tc_name = "Chained_operations_backward";
+        // Sub-test 1: (a-b)*c
+        {
+            TensorShape v_shape = {2};
+            float a_data[] = {3.0f, 4.0f};
+            float b_data[] = {1.0f, 2.0f};
+            float c_data[] = {2.0f, 3.0f};
+            float exp_grad_a[] = {2.0f, 3.0f};
+            float exp_grad_b[] = {-2.0f, -3.0f};
+            float exp_grad_c[] = {2.0f, 2.0f};
+            
+            Tensor a = create_test_tensor(v_shape, a_data, true);
+            Tensor b = create_test_tensor(v_shape, b_data, true);
+            Tensor c = create_test_tensor(v_shape, c_data, true);
+            
+            Tensor diff = Tensor_sub(a, b);
+            Tensor prod = Tensor_mul(diff, c);
+            Tensor l = Tensor_sum(prod);
+            
+            Tensor_backward(l, (Tensor){0});
+            
+            Tensor expected_grad_a = create_test_tensor(v_shape, exp_grad_a, false);
+            Tensor expected_grad_b = create_test_tensor(v_shape, exp_grad_b, false);
+            Tensor expected_grad_c = create_test_tensor(v_shape, exp_grad_c, false);
+
+            compare_tensors(&a.node->grad, &expected_grad_a, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&b.node->grad, &expected_grad_b, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+            compare_tensors(&c.node->grad, &expected_grad_c, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    cten_free(pool_id);
+}

--- a/tests/cten_tests.c
+++ b/tests/cten_tests.c
@@ -30,6 +30,9 @@ void test_div_operator();
 void test_add_backward();
 void test_mul_backward();
 void test_matmul_backward();
+void test_sub_backward();
+void test_relu_backward();
+void test_linear_backward();
 
 int main() {
     printf("Starting cTensor Test Suite on %s...\n", PLATFORM_NAME);
@@ -103,8 +106,17 @@ int main() {
     test_matmul_backward();
     printf("Matmul backward tests finished.\n");
     
-    //other test functions
+    test_sub_backward();
+    printf("Sub backward tests finished.\n");
+    
+    test_relu_backward();
+    printf("ReLU backward tests finished.\n");
+    
+    test_linear_backward();
+    printf("Linear backward tests finished.\n");
 
+    // other tests
+    
     csv_reporter_close();
     cten_finalize();
 


### PR DESCRIPTION
This PR implements the backwards pass for the subtraction, ReLU, and linear layer operations, enabling gradient computation for these key functions.

- Adds unit tests for the new backwards implementations.
- Fixes a bug in Tensor_sub to correctly handle gradients for broadcasted inputs.

TODO: The backwards passes for Tensor_sum and Tensor_mean are currently non-functional because they are implemented as macros and do not create computation graph nodes(most probably). This will be addressed in a future PR by converting them to proper functions with corresponding gradient implementation