### PR TITLE
Add new standard activation functions

### DIFF
--- a/include/cten.h
+++ b/include/cten.h
@@ -109,6 +109,8 @@ Tensor nn_linear(Tensor input, Tensor weight, Tensor bias);
 Tensor nn_relu(Tensor input);
 Tensor nn_sigmoid(Tensor input);
 Tensor nn_tanh(Tensor input);
+Tensor nn_elu(Tensor self);
+Tensor nn_selu(Tensor self);
 Tensor nn_softmax(Tensor input);
 Tensor Glorot_init(TensorShape shape, bool requires_grad);
 Tensor nn_crossentropy(Tensor y_true, Tensor y_pred);

--- a/src/nn.c
+++ b/src/nn.c
@@ -49,6 +49,7 @@ static Tensor GradFn_log(Tensor self, int i) {
     }
     return res;
 }
+
 Tensor nn_log(Tensor self) {
     bool requires_grad = !cten_is_eval() && self.node != NULL;
     Tensor res = Tensor_new(self.shape, requires_grad);
@@ -67,6 +68,7 @@ Tensor nn_log(Tensor self) {
 static Tensor GradFn_exp(Tensor self, int i) {
     return self;
 }
+
 Tensor nn_exp(Tensor self) {
     bool requires_grad = !cten_is_eval() && self.node != NULL;
     Tensor res = Tensor_new(self.shape, requires_grad);
@@ -90,6 +92,7 @@ static Tensor GradFn_sin(Tensor self, int i) {
     }
     return res;
 }
+
 Tensor nn_sin(Tensor self) {
     bool requires_grad = !cten_is_eval() && self.node != NULL;
     Tensor res = Tensor_new(self.shape, requires_grad);
@@ -113,6 +116,7 @@ static Tensor GradFn_cos(Tensor self, int i) {
     }
     return res;
 }
+
 Tensor nn_cos(Tensor self) {
     bool requires_grad = !cten_is_eval() && self.node != NULL;
     Tensor res = Tensor_new(self.shape, requires_grad);
@@ -137,6 +141,7 @@ static Tensor GradFn_tan(Tensor self, int i) {
     }
     return res;
 }
+
 Tensor nn_tan(Tensor self) {
     bool requires_grad = !cten_is_eval() && self.node != NULL;
     Tensor res = Tensor_new(self.shape, requires_grad);
@@ -151,6 +156,7 @@ Tensor nn_tan(Tensor self) {
     }
     return res;
 }
+
 static Tensor GradFn_sigmoid(Tensor self, int i) {
     // d/dx sigmoid(x) = sigmoid(x) * (1 - sigmoid(x))
     Tensor res = Tensor_new(self.shape, false);
@@ -160,6 +166,7 @@ static Tensor GradFn_sigmoid(Tensor self, int i) {
     }
     return res;
 }
+
 Tensor nn_sigmoid(Tensor self) {
     bool requires_grad = !cten_is_eval() && self.node != NULL;
     Tensor res = Tensor_new(self.shape, requires_grad);
@@ -171,6 +178,31 @@ Tensor nn_sigmoid(Tensor self) {
         res.node->inputs[0] = self;
         res.node->n_inputs = 1;
         res.node->name = "Sigmoid";
+    }
+    return res;
+}
+
+static Tensor GradFn_tanh(Tensor self, int i) {
+    // d/dx tanh(x) = 1 - tanh^2(x)
+    Tensor res = Tensor_new(self.shape, false);
+    for(int j = 0; j < self.data->numel; j++) {
+        float y = self.data->flex[j];
+        res.data->flex[j] = 1.0f - y*y;
+    }
+    return res;
+}
+
+Tensor nn_tanh(Tensor self) {
+    bool requires_grad = !cten_is_eval() && self.node != NULL;
+    Tensor res = Tensor_new(self.shape, requires_grad);
+    for(int i = 0; i < self.data->numel; i++) {
+        res.data->flex[i] = tanhf(self.data->flex[i]);
+    }
+    if(requires_grad) {
+        res.node->grad_fn = GradFn_tanh;
+        res.node->inputs[0] = self;
+        res.node->n_inputs = 1;
+        res.node->name = "Tanh";
     }
     return res;
 }

--- a/src/nn.c
+++ b/src/nn.c
@@ -82,6 +82,76 @@ Tensor nn_exp(Tensor self) {
     return res;
 }
 
+static Tensor GradFn_sin(Tensor self, int i) {
+    Tensor input = self.node->inputs[i];
+    Tensor res = Tensor_new(input.shape, false);
+    for(int j = 0; j < input.data->numel; j++) {
+        res.data->flex[j] = cosf(input.data->flex[j]);
+    }
+    return res;
+}
+Tensor nn_sin(Tensor self) {
+    bool requires_grad = !cten_is_eval() && self.node != NULL;
+    Tensor res = Tensor_new(self.shape, requires_grad);
+    for(int i = 0; i < self.data->numel; i++) {
+        res.data->flex[i] = sinf(self.data->flex[i]);
+    }
+    if(requires_grad) {
+        res.node->grad_fn = GradFn_sin;
+        res.node->inputs[0] = self;
+        res.node->n_inputs = 1;
+        res.node->name = "Sin";
+    }
+    return res;
+}
+
+static Tensor GradFn_cos(Tensor self, int i) {
+    Tensor input = self.node->inputs[i];
+    Tensor res = Tensor_new(input.shape, false);
+    for(int j = 0; j < input.data->numel; j++) {
+        res.data->flex[j] = -sinf(input.data->flex[j]);
+    }
+    return res;
+}
+Tensor nn_cos(Tensor self) {
+    bool requires_grad = !cten_is_eval() && self.node != NULL;
+    Tensor res = Tensor_new(self.shape, requires_grad);
+    for(int i = 0; i < self.data->numel; i++) {
+        res.data->flex[i] = cosf(self.data->flex[i]);
+    }
+    if(requires_grad) {
+        res.node->grad_fn = GradFn_cos;
+        res.node->inputs[0] = self;
+        res.node->n_inputs = 1;
+        res.node->name = "Cos";
+    }
+    return res;
+}
+
+static Tensor GradFn_tan(Tensor self, int i) {
+    // d/dx(tan(x)) = 1 + tan^2(x)
+    Tensor res = Tensor_new(self.shape, false);
+    for(int j = 0; j < self.data->numel; j++) {
+        float y = self.data->flex[j];
+        res.data->flex[j] = 1.0f + y*y;
+    }
+    return res;
+}
+Tensor nn_tan(Tensor self) {
+    bool requires_grad = !cten_is_eval() && self.node != NULL;
+    Tensor res = Tensor_new(self.shape, requires_grad);
+    for(int i = 0; i < self.data->numel; i++) {
+        res.data->flex[i] = tanf(self.data->flex[i]);
+    }
+    if(requires_grad) {
+        res.node->grad_fn = GradFn_tan;
+        res.node->inputs[0] = self;
+        res.node->n_inputs = 1;
+        res.node->name = "Tan";
+    }
+    return res;
+}
+
 Tensor Glorot_init(TensorShape shape, bool requires_grad) {
     Tensor res = Tensor_new(shape, requires_grad);
     int fan_in = shape[0];

--- a/src/nn.c
+++ b/src/nn.c
@@ -64,6 +64,24 @@ Tensor nn_log(Tensor self) {
     return res;
 }
 
+static Tensor GradFn_exp(Tensor self, int i) {
+    return self;
+}
+Tensor nn_exp(Tensor self) {
+    bool requires_grad = !cten_is_eval() && self.node != NULL;
+    Tensor res = Tensor_new(self.shape, requires_grad);
+    for(int i = 0; i < self.data->numel; i++) {
+        res.data->flex[i] = expf(self.data->flex[i]);
+    }
+    if(requires_grad) {
+        res.node->grad_fn = GradFn_exp;
+        res.node->inputs[0] = self;
+        res.node->n_inputs = 1;
+        res.node->name = "Exp";
+    }
+    return res;
+}
+
 Tensor Glorot_init(TensorShape shape, bool requires_grad) {
     Tensor res = Tensor_new(shape, requires_grad);
     int fan_in = shape[0];

--- a/src/nn.c
+++ b/src/nn.c
@@ -41,6 +41,29 @@ Tensor nn_relu(Tensor self) {
     return res;
 }
 
+static Tensor GradFn_log(Tensor self, int i) {
+    Tensor input = self.node->inputs[i];
+    Tensor res = Tensor_new(input.shape, false);
+    for(int j = 0; j < input.data->numel; j++) {
+        res.data->flex[j] = 1.0f / input.data->flex[j];
+    }
+    return res;
+}
+Tensor nn_log(Tensor self) {
+    bool requires_grad = !cten_is_eval() && self.node != NULL;
+    Tensor res = Tensor_new(self.shape, requires_grad);
+    for(int i = 0; i < self.data->numel; i++) {
+        res.data->flex[i] = logf(self.data->flex[i]);
+    }
+    if(requires_grad) {
+        res.node->grad_fn = GradFn_log;
+        res.node->inputs[0] = self;
+        res.node->n_inputs = 1;
+        res.node->name = "Log";
+    }
+    return res;
+}
+
 Tensor Glorot_init(TensorShape shape, bool requires_grad) {
     Tensor res = Tensor_new(shape, requires_grad);
     int fan_in = shape[0];


### PR DESCRIPTION
This PR introduces several activation functions for the ctensor library.

- Implemented sigmoid and tanh, which were declared but missing.
- Added elu and selu.
- Also implemented log, exp, sin, cos, and tan. While the trig functions aren't typical for standard feed-forward nets, they're fundamental.