### PR TITLE
[Fix] : Correct Softmax Gradient

### DIFF
--- a/include/cten.h
+++ b/include/cten.h
@@ -35,6 +35,7 @@ typedef struct GradNode {
     struct Tensor inputs[4];
     int n_inputs;
     const char* name;
+    int params[4];
 } GradNode;
 
 typedef struct {
@@ -111,7 +112,7 @@ Tensor nn_sigmoid(Tensor input);
 Tensor nn_tanh(Tensor input);
 Tensor nn_elu(Tensor self, float alpha);
 Tensor nn_selu(Tensor self);
-Tensor nn_softmax(Tensor input);
+Tensor nn_softmax(Tensor input, int dim);
 Tensor Glorot_init(TensorShape shape, bool requires_grad);
 Tensor nn_crossentropy(Tensor y_true, Tensor y_pred);
 Tensor nn_softmax_crossentropy(Tensor y_true, Tensor logits);

--- a/src/basic.c
+++ b/src/basic.c
@@ -175,7 +175,9 @@ void Tensor_backward(Tensor self, Tensor grad) {
         
         // Step 2: Apply the chain rule (upstream_grad * local_grad)
         Tensor combined_grad;
-        if(strcmp(self.node->name, "Matmul") == 0) {
+        if (strcmp(self.node->name, "Softmax") == 0) {
+            combined_grad = input_grad;
+        } else if(strcmp(self.node->name, "Matmul") == 0) {
             if (i == 0) {
                 combined_grad = Tensor_matmul(grad, input_grad);
             } else {

--- a/src/operator.c
+++ b/src/operator.c
@@ -82,7 +82,6 @@ Tensor Tensor_mul(Tensor self, Tensor other) {
     return res;
 }
 
-
 Tensor Tensor_mulf(Tensor self, float other) {
     Tensor tmp = Tensor_new(self.shape, false);
     for(int i = 0; i < tmp.data->numel; i++) {
@@ -282,7 +281,6 @@ static Tensor GradFn_sub(Tensor self, int i) {
     }
     return res;
 }
-
 
 static Tensor GradFn_div(Tensor self, int i) {
     Tensor res = Tensor_new(self.shape, false);


### PR DESCRIPTION
This PR fixes a tricky bug in our softmax backwards pass, where the gradients weren't matching up with PyTorch Results.

Fixed GradFn_softmax to ensure it correctly computes the full Jacobian-vector product and Tensor_backward to recognise "Softmax" as a special case. Now, it knows to use the gradient from GradFn_softmax directly, skipping the extra multiplication