### PR TITLE
[Feat] : Add AdaGrad, RMSProp, and Adam Optimizers

### DIFF
--- a/include/cten.h
+++ b/include/cten.h
@@ -129,12 +129,30 @@ void cten_free(PoolId id);
 
 /* Optimizer */
 typedef struct optim_sgd optim_sgd;
+typedef struct optim_adagrad optim_adagrad;
+typedef struct optim_rmsprop optim_rmsprop;
+typedef struct optim_adam optim_adam;
 
+//SGD
 optim_sgd* optim_sgd_new(int n_params, Tensor* params);
 void optim_sgd_config(optim_sgd* self, float lr, float momentum);
 void optim_sgd_zerograd(optim_sgd* self);
 void optim_sgd_step(optim_sgd* self);
-void optim_sgd_delete(optim_sgd* self);
+
+//AdaGrad
+optim_adagrad* optim_adagrad_new(int n_params, Tensor* params, float lr, float eps);
+void optim_adagrad_zerograd(optim_adagrad* self);
+void optim_adagrad_step(optim_adagrad* self);
+
+//RMSProp
+optim_rmsprop* optim_rmsprop_new(int n_params, Tensor* params, float lr, float alpha, float eps);
+void optim_rmsprop_zerograd(optim_rmsprop* self);
+void optim_rmsprop_step(optim_rmsprop* self);
+
+//Adam
+optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float beta1, float beta2, float eps);
+void optim_adam_zerograd(optim_adam* self);
+void optim_adam_step(optim_adam* self);
 
 /* Misc */
 void cten_begin_eval();

--- a/src/optimizer/sgd.c
+++ b/src/optimizer/sgd.c
@@ -126,3 +126,59 @@ void optim_rmsprop_step(optim_rmsprop* self) {
         }
     }
 }
+
+typedef struct optim_adam {
+    int n_params;
+    Tensor* params;
+    float lr;
+    float β1;
+    float β2;
+    float ε;
+    Tensor* m;
+    Tensor* v;
+    int t;
+} optim_adam;
+
+optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float β1, float β2, float ε) {
+    optim_adam* self = _cten_malloc(sizeof(optim_adam));
+    self->n_params = n_params;
+    self->params = params;
+    self->lr = lr;
+    self->β1 = β1;
+    self->β2 = β2;
+    self->ε = ε;
+    self->t = 0;
+
+    self->m = _cten_malloc(sizeof(Tensor) * n_params);
+    self->v = _cten_malloc(sizeof(Tensor) * n_params);
+    for (int i = 0; i < n_params; i++) {
+        self->m[i] = Tensor_zeros(params[i].shape, false);
+        self->v[i] = Tensor_zeros(params[i].shape, false);
+    }
+    return self;
+}
+
+void optim_adam_zerograd(optim_adam* self) {
+    _cten_zero_grad(self->params, self->n_params);
+}
+
+void optim_adam_step(optim_adam* self) {
+    self->t++;
+    for (int i = 0; i < self->n_params; i++) {
+        Tensor p = self->params[i];
+        if (p.node == NULL || p.node->grad.data == NULL) continue;
+
+        Tensor grad = p.node->grad;
+        Tensor* m = &self->m[i];
+        Tensor* v = &self->v[i];
+
+        for (int j = 0; j < p.data->numel; j++) {
+            float g = grad.data->flex[j];
+            m->data->flex[j] = self->β1 * m->data->flex[j] + (1 - self->β1) * g;
+            v->data->flex[j] = self->β2 * v->data->flex[j] + (1 - self->β2) * g * g;
+            float m_hat = m->data->flex[j] / (1 - powf(self->β1, self->t));
+            float v_hat = v->data->flex[j] / (1 - powf(self->β2, self->t));
+            p.data->flex[j] -= self->lr * m_hat / (sqrtf(v_hat) + self->ε);
+        }
+    }
+}

--- a/src/optimizer/sgd.c
+++ b/src/optimizer/sgd.c
@@ -82,3 +82,47 @@ void optim_adagrad_step(optim_adagrad* self) {
         }
     }
 }
+
+typedef struct optim_rmsprop {
+    int n_params;
+    Tensor* params;
+    float lr;
+    float β;
+    float ε;
+    Tensor* squared_avg;
+} optim_rmsprop;
+
+optim_rmsprop* optim_rmsprop_new(int n_params, Tensor* params, float lr, float β, float ε) {
+    optim_rmsprop* self = _cten_malloc(sizeof(optim_rmsprop));
+    self->n_params = n_params;
+    self->params = params;
+    self->lr = lr;
+    self->β = β;
+    self->ε = ε;
+
+    self->squared_avg = _cten_malloc(sizeof(Tensor) * n_params);
+    for (int i = 0; i < n_params; i++) {
+        self->squared_avg[i] = Tensor_zeros(params[i].shape, false);
+    }
+    return self;
+}
+
+void optim_rmsprop_zerograd(optim_rmsprop* self) {
+    _cten_zero_grad(self->params, self->n_params);
+}
+
+void optim_rmsprop_step(optim_rmsprop* self) {
+    for (int i = 0; i < self->n_params; i++) {
+        Tensor t = self->params[i];
+        if (t.node == NULL || t.node->grad.data == NULL) continue;
+
+        Tensor grad = t.node->grad;
+        Tensor* sq_avg = &self->squared_avg[i];
+
+        for (int j = 0; j < t.data->numel; j++) {
+            float g = grad.data->flex[j];
+            sq_avg->data->flex[j] = self->β * sq_avg->data->flex[j] + (1 - self->β) * g * g;
+            t.data->flex[j] -= self->lr * g / (sqrtf(sq_avg->data->flex[j]) + self->ε);
+        }
+    }
+}

--- a/src/optimizer/sgd.c
+++ b/src/optimizer/sgd.c
@@ -1,6 +1,6 @@
 #include "cten.h"
 #include "cten_internal.h"
-
+#include <math.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +38,47 @@ void optim_sgd_step(optim_sgd* self) {
         // step
         for(int j = 0; j < t.data->numel; j++) {
             t.data->flex[j] -= self->lr * t.node->grad.data->flex[j];
+        }
+    }
+}
+
+typedef struct optim_adagrad {
+    int n_params;
+    Tensor* params;
+    float lr;
+    float ε;
+    Tensor* sum_sq_grad;
+} optim_adagrad;
+
+optim_adagrad* optim_adagrad_new(int n_params, Tensor* params, float lr, float ε) {
+    optim_adagrad* self = _cten_malloc(sizeof(optim_adagrad));
+    self->n_params = n_params;
+    self->params = params;
+    self->lr = lr;
+    self->ε = ε;
+    self->sum_sq_grad = _cten_malloc(sizeof(Tensor) * n_params);
+    for (int i = 0; i < n_params; i++) {
+        self->sum_sq_grad[i] = Tensor_zeros(params[i].shape, false);
+    }
+    return self;
+}
+
+void optim_adagrad_zerograd(optim_adagrad* self) {
+    _cten_zero_grad(self->params, self->n_params);
+}
+
+void optim_adagrad_step(optim_adagrad* self) {
+    for (int i = 0; i < self->n_params; i++) {
+        Tensor t = self->params[i];
+        if (t.node == NULL || t.node->grad.data == NULL) continue;
+
+        Tensor grad = t.node->grad;
+        Tensor* sum_sq = &self->sum_sq_grad[i];
+
+        for (int j = 0; j < t.data->numel; j++) {
+            float g = grad.data->flex[j];
+            sum_sq->data->flex[j] += g * g;
+            t.data->flex[j] -= self->lr * g / (sqrtf(sum_sq->data->flex[j]) + self->ε);
         }
     }
 }


### PR DESCRIPTION
Just added a few more optimisers to have some more powerful options for training! This PR brings in AdaGrad, RMSProp, and the classic Adam.

- Added the new optimizers (AdaGrad, RMSProp, Adam) to the main optimizer file. I put them all in src/optimizer/sgd.c for now, but we can totally break them into separate files later if we want.
- Updated cten.h with the new function declarations so they can be used across the project.
- Kept SGD as is, so nothing breaks there.