### PR TITLE
[Feat] : Add weight decay support to all optimizers

### DIFF
--- a/include/cten.h
+++ b/include/cten.h
@@ -134,23 +134,23 @@ typedef struct optim_rmsprop optim_rmsprop;
 typedef struct optim_adam optim_adam;
 
 //SGD
-optim_sgd* optim_sgd_new(int n_params, Tensor* params);
+optim_sgd* optim_sgd_new(int n_params, Tensor* params, float weight_decay);
 void optim_sgd_config(optim_sgd* self, float lr, float momentum);
 void optim_sgd_zerograd(optim_sgd* self);
 void optim_sgd_step(optim_sgd* self);
 
 //AdaGrad
-optim_adagrad* optim_adagrad_new(int n_params, Tensor* params, float lr, float eps);
+optim_adagrad* optim_adagrad_new(int n_params, Tensor* params, float lr, float ε,float weight_decay);
 void optim_adagrad_zerograd(optim_adagrad* self);
 void optim_adagrad_step(optim_adagrad* self);
 
 //RMSProp
-optim_rmsprop* optim_rmsprop_new(int n_params, Tensor* params, float lr, float alpha, float eps);
+optim_rmsprop* optim_rmsprop_new(int n_params, Tensor* params, float lr, float β, float ε,float weight_decay);
 void optim_rmsprop_zerograd(optim_rmsprop* self);
 void optim_rmsprop_step(optim_rmsprop* self);
 
 //Adam
-optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float beta1, float beta2, float eps);
+optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float β1, float β2, float ε,float weight_decay);
 void optim_adam_zerograd(optim_adam* self);
 void optim_adam_step(optim_adam* self);
 


### PR DESCRIPTION
Added L2 regularisation (weight decay) to SGD, AdaGrad, RMSProp, and Adam optimisers. Each optimizer now takes an additional weight_decay parameter in its constructor.

- Modified all optimiser constructors to accept a weight decay parameter
- Gradient calculation now includes the weight_decay * param_value term

Quick Eg.
```c
// Before: optim_sgd_new(n_params, params)
// After: optim_sgd_new(n_params, params, 0.01f)  // 0.01 weight decay
```
Should help keep those models from going crazy on the training data!!! 😮‍💨 