### PR TITLE
[Feat] : Add gradient clipping utilities for neural network training

### DIFF
--- a/include/cten.h
+++ b/include/cten.h
@@ -154,6 +154,13 @@ optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float β1, fl
 void optim_adam_zerograd(optim_adam* self);
 void optim_adam_step(optim_adam* self);
 
+/* Gradient Clipping */
+void cten_clip_grad_norm(Tensor* params, int n_params, float max_norm);
+void cten_clip_grad_value(Tensor* params, int n_params, float max_value);
+void cten_clip_grad_value_range(Tensor* params, int n_params, float min_value, float max_value);
+void cten_clip_grad_positive(Tensor* params, int n_params, float max_value);
+void cten_clip_grad_negative(Tensor* params, int n_params, float min_value);
+
 /* Misc */
 void cten_begin_eval();
 bool cten_is_eval();

--- a/include/cten.h
+++ b/include/cten.h
@@ -134,23 +134,23 @@ typedef struct optim_rmsprop optim_rmsprop;
 typedef struct optim_adam optim_adam;
 
 //SGD
-optim_sgd* optim_sgd_new(int n_params, Tensor* params);
+optim_sgd* optim_sgd_new(int n_params, Tensor* params, float weight_decay);
 void optim_sgd_config(optim_sgd* self, float lr, float momentum);
 void optim_sgd_zerograd(optim_sgd* self);
 void optim_sgd_step(optim_sgd* self);
 
 //AdaGrad
-optim_adagrad* optim_adagrad_new(int n_params, Tensor* params, float lr, float eps);
+optim_adagrad* optim_adagrad_new(int n_params, Tensor* params, float lr, float ε,float weight_decay);
 void optim_adagrad_zerograd(optim_adagrad* self);
 void optim_adagrad_step(optim_adagrad* self);
 
 //RMSProp
-optim_rmsprop* optim_rmsprop_new(int n_params, Tensor* params, float lr, float alpha, float eps);
+optim_rmsprop* optim_rmsprop_new(int n_params, Tensor* params, float lr, float β, float ε,float weight_decay);
 void optim_rmsprop_zerograd(optim_rmsprop* self);
 void optim_rmsprop_step(optim_rmsprop* self);
 
 //Adam
-optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float beta1, float beta2, float eps);
+optim_adam* optim_adam_new(int n_params, Tensor* params, float lr, float β1, float β2, float ε,float weight_decay);
 void optim_adam_zerograd(optim_adam* self);
 void optim_adam_step(optim_adam* self);
 


### PR DESCRIPTION
This PR introduces essential gradient clipping functionality to help stabilise training and prevent gradient explosion

New Functions:

- cten_clip_grad_norm() - Clips gradients by global norm (L2)
```c
// Clip gradients by their overall magnitude
void cten_clip_grad_norm(Tensor* params, int n_params, float max_norm);
```
- cten_clip_grad_value() - Clips gradients to symmetric range [-max, max]
```c
// Clip gradients to stay within [-max_value, max_value] 
void cten_clip_grad_value(Tensor* params, int n_params, float max_value);
```
- cten_clip_grad_value_range() - Clips gradients to custom [min, max] range
```c
// Clip gradients to custom range [min_value, max_value]
void cten_clip_grad_value_range(Tensor* params, int n_params, float min_value, float max_value);
```
- cten_clip_grad_positive() - Clips only positive gradients above threshold
```c
// Only clip gradients that are too positive (> max_value)
void cten_clip_grad_positive(Tensor* params, int n_params, float max_value);
```
- cten_clip_grad_negative() - Clips only negative gradients below the threshold
```c
// Only clip gradients that are too negative (< min_value)  
void cten_clip_grad_negative(Tensor* params, int n_params, float min_value);
```