### PR TITLE
Broadcasting for Tensor matmul operation on 3D and 4D matrices.

### DIFF
--- a/include/cten.h
+++ b/include/cten.h
@@ -274,6 +274,23 @@ Tensor Tensor_divf(Tensor self, float other);
 Tensor Tensor_powf(Tensor self, float other);
 
 /**
+ * @brief Performs batch matrix multiplication for two 3D tensors.
+ *        For each batch index, multiplies the corresponding {m, n} and {n, p} matrices:
+ *        - self: shape {batch, m, n}
+ *        - other: shape {batch, n, p}
+ *        Returns a tensor of shape {batch, m, p} where each slice is the matrix product of the input slices.
+ *        Only supports strictly matched batch sizes and no broadcasting.
+ *        Each batch slice is extracted using Tensor_batch_slice, and standard Tensor_matmul is applied.
+ *        Prints the dimensions for each batch multiplication for debugging.
+ *        The output tensor contains all resulting batch matrix products.
+ *
+ * @param self Input tensor of shape {batch, m, n}
+ * @param other Input tensor of shape {batch, n, p}
+ * @return Output tensor of shape {batch, m, p} with the results of all batch multiplications
+ */
+Tensor Tensor_matmul_batch(Tensor self, Tensor other);
+
+/**
  * @brief Matrix multiplication of two tensors
  * @param self First tensor (left operand)
  * @param other Second tensor (right operand)

--- a/src/operator.c
+++ b/src/operator.c
@@ -7,6 +7,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #ifdef Tensor_mean
 #undef Tensor_mean
@@ -226,14 +227,103 @@ Tensor Tensor_sum(Tensor self, ...) {
 
 static Tensor GradFn_matmul(Tensor self, int i) {
     return Tensor_transpose(Tensor_detach(self.node->inputs[1 - i]));
-    ;
+}
+
+Tensor Tensor_batch_slice(Tensor t, int batch_idx, int group_idx) {
+    int dim = TensorShape_dim(t.shape);
+
+    int m, n, offset;
+    TensorShape slice_shape = {0, 0, 0, 0};
+
+    if (dim == 3) {
+        int b = t.shape[0]; m = t.shape[1]; n = t.shape[2];
+        assert(batch_idx >= 0 && batch_idx < b);
+
+        offset = batch_idx * m * n;
+        slice_shape[0] = m; slice_shape[1] = n;
+    } else if (dim == 4) {
+        int b = t.shape[0], g = t.shape[1];
+        m = t.shape[2]; n = t.shape[3];
+        
+        assert(batch_idx >= 0 && batch_idx < b);
+        assert(group_idx >= 0 && group_idx < g);
+        offset = (batch_idx * g + group_idx) * m * n;
+        slice_shape[0] = m; slice_shape[1] = n;
+    } else {
+        assert(0);
+    }
+
+    Tensor res = Tensor_new(slice_shape, t.node != NULL);
+    memcpy(res.data->flex, t.data->flex + offset, sizeof(float) * m * n);
+    return res;
+}
+
+Tensor Tensor_matmul_batch(Tensor self, Tensor other) {
+    int self_dim = TensorShape_dim(self.shape);
+    int other_dim = TensorShape_dim(other.shape);
+
+    assert((self_dim == 3 || self_dim == 4) && (other_dim == 3 || other_dim == 4));
+
+    // broadcasting
+    int batch = (self.shape[0] > other.shape[0]) ? self.shape[0] : other.shape[0];
+
+    int self_g = (self_dim == 4) ? self.shape[1] : 1;
+    int other_g = (other_dim == 4) ? other.shape[1] : 1;
+    int group = (self_g > other_g) ? self_g : other_g;
+
+    int m = self.shape[self_dim - 2];
+    int n = self.shape[self_dim - 1];
+    int p = other.shape[other_dim - 1];
+    // {b,g,m,n} * {b,g,n,p} -> {b,g,m,p} (g=1 for 3D)
+    
+    assert(n == other.shape[other_dim - 2]);
+
+    TensorShape res_shape = {batch, m, p, 0};
+    if (group > 1) {
+        res_shape[0] = batch;
+        res_shape[1] = group;
+        res_shape[2] = m;
+        res_shape[3] = p;
+    }
+
+    Tensor res = Tensor_new(res_shape, self.node != NULL || other.node != NULL);
+    for(int b = 0; b < batch; b++) {
+        int selfbatch = self.shape[0] <= b ? self.shape[0] - 1 : b;
+        int otherbatch = other.shape[0] <= b ? other.shape[0] - 1 : b;
+
+        for(int g = 0; g < group; g++) {
+            int selfgroup = self_g <= g ? self_g - 1 : g;
+            int othergroup = other_g <= g ? other_g - 1 : g;
+
+            Tensor self_slice = Tensor_batch_slice(self, selfbatch, selfgroup);
+            Tensor other_slice = Tensor_batch_slice(other, otherbatch, othergroup);
+            Tensor res_slice = Tensor_matmul(self_slice, other_slice);
+
+            int offset = ((batch > 1) ? b * group + g : g) * m * p;
+            memcpy(res.data->flex + offset, res_slice.data->flex, sizeof(float) * m * p);
+        }
+    }
+
+    if(res.node != NULL) {
+        res.node->grad_fn = GradFn_matmul;
+        res.node->inputs[0] = self;
+        res.node->inputs[1] = other;
+        res.node->n_inputs = 2;
+        res.node->name = "MatmulBatch";
+    }
+    return res;
 }
 
 Tensor Tensor_matmul(Tensor self, Tensor other) {
     int self_dim = TensorShape_dim(self.shape);
     int other_dim = TensorShape_dim(other.shape);
+
     assert(self_dim >= 2);
     assert(other_dim >= 2);
+
+    if (self_dim > 2 || other_dim > 2) {
+        return Tensor_matmul_batch(self, other);
+    }
 
     int m = self.shape[self_dim - 2];
     int n = self.shape[self_dim - 1];
@@ -244,10 +334,9 @@ Tensor Tensor_matmul(Tensor self, Tensor other) {
     TensorShape res_shape;
     memcpy(res_shape, self.shape, sizeof(TensorShape));
     res_shape[self_dim - 1] = p;
-    Tensor res = Tensor_new(
-        res_shape,
-        self.node != NULL ||
-            other.node != NULL);  // here weight/bias have .node != NULL, so res have GradNode
+
+    // here weight/bias have .node != NULL, so res have GradNode
+    Tensor res = Tensor_new(res_shape, self.node != NULL || other.node != NULL);
 
     for(int i = 0; i < m; i++) {
         for(int j = 0; j < p; j++) {

--- a/tests/Operator/test_matmul.c
+++ b/tests/Operator/test_matmul.c
@@ -259,37 +259,161 @@ void test_matmul_operator() {
         }
     }
 
-    // TODO : Currently MatMul Doesnt support batch matrix multiplication
-    //
-    // // Test Case 8: Batch Matrix Multiplication
-    // {
-    //     const char* tc_name = "matmul_batch_matrices";
+    // Test Case 8: Batch Matrix Multiplication
+    
+    {
+        const char* tc_name = "matmul_batch_matrices";
 
-    //     // Sub-test 1: Batch matrix multiplication (2x3x4 * 2x4x5)
-    //     {
-    //         TensorShape s1_shape = {2, 3, 4};
-    //         float d1[] = {0.9256f, 0.4219f, 0.3916f, 0.6438f, 0.8790f, 0.0543f, 0.0463f, 0.5632f,
-    //         0.7813f, 0.9841f, 0.7979f, 0.8884f, 0.5976f, 0.0739f, 0.8306f, 0.0435f, 0.2653f,
-    //         0.7424f, 0.9176f, 0.6326f, 0.2545f, 0.6777f, 0.9430f, 0.4921f}; TensorShape s2_shape
-    //         = {2, 4, 5}; float d2[] = {0.1146f, 0.8401f, 0.0189f, 0.9417f, 0.9551f, 0.3073f,
-    //         0.5162f, 0.6919f, 0.3872f, 0.9831f, 0.8261f, 0.6104f, 0.1850f, 0.4844f, 0.0732f,
-    //         0.8003f, 0.3244f, 0.6337f, 0.4984f, 0.1917f, 0.5972f, 0.8280f, 0.1163f, 0.1445f,
-    //         0.5281f, 0.3753f, 0.7377f, 0.0097f, 0.0460f, 0.8825f, 0.1283f, 0.3434f, 0.9592f,
-    //         0.2614f, 0.8935f, 0.9233f, 0.1056f, 0.1819f, 0.9243f, 0.1263f}; TensorShape exp_shape
-    //         = {2, 3, 5}; float exp_d[] = {1.0745f, 1.4433f, 0.7899f, 1.5456f, 1.4509f, 0.6064f,
-    //         0.9774f, 0.4197f, 1.1520f, 1.0043f, 1.7620f, 1.9396f, 1.4062f, 1.9461f, 1.9424f,
-    //         0.5314f, 0.8391f, 0.8748f, 0.3471f, 1.1284f, 1.1388f, 1.1492f, 1.0333f,
-    //         0.8970f, 1.6950f, 0.9817f, 1.0865f, 1.0302f, 0.7693f, 1.6373f};
+        // Sub-test 1: Batch matrix multiplication (2x3x4 * 2x4x5) - existing
+        {
+            TensorShape s1_shape = {2, 3, 4};
+            float d1[] = {0.9256f, 0.4219f, 0.3916f, 0.6438f, 0.8790f, 0.0543f, 0.0463f, 0.5632f,
+            0.7813f, 0.9841f, 0.7979f, 0.8884f, 0.5976f, 0.0739f, 0.8306f, 0.0435f, 0.2653f,
+            0.7424f, 0.9176f, 0.6326f, 0.2545f, 0.6777f, 0.9430f, 0.4921f};
 
-    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
-    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
-    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
-    //         Tensor actual_res = Tensor_matmul(t1, t2);
+            TensorShape s2_shape= {2, 4, 5};
+            float d2[] = {0.1146f, 0.8401f, 0.0189f, 0.9417f, 0.9551f, 0.3073f,
+            0.5162f, 0.6919f, 0.3872f, 0.9831f, 0.8261f, 0.6104f, 0.1850f, 0.4844f, 0.0732f,
+            0.8003f, 0.3244f, 0.6337f, 0.4984f, 0.1917f, 0.5972f, 0.8280f, 0.1163f, 0.1445f,
+            0.5281f, 0.3753f, 0.7377f, 0.0097f, 0.0460f, 0.8825f, 0.1283f, 0.3434f, 0.9592f,
+            0.2614f, 0.8935f, 0.9233f, 0.1056f, 0.1819f, 0.9243f, 0.1263f};
+            
+            TensorShape exp_shape = {2, 3, 5};
+            float exp_d[] = {1.0745f, 1.4433f, 0.7899f, 1.5456f, 1.4509f, 0.6064f,
+            0.9774f, 0.4197f, 1.1520f, 1.0043f, 1.7620f, 1.9396f, 1.4062f, 1.9461f, 1.9424f,
+            0.5314f, 0.8391f, 0.8748f, 0.3471f, 1.1284f, 1.1388f, 1.1492f, 1.0333f,
+            0.8970f, 1.6950f, 0.9817f, 1.0865f, 1.0302f, 0.7693f, 1.6373f};
 
-    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1,
-    //         TEST_FLOAT_TOLERANCE);
-    //     }
-    // }
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1,
+            TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test case 1.1: Batch matrix multiplication using integers only (2x3x4 * 2x4x5)
+        {
+            TensorShape s1_shape = {2, 3, 4};
+            float d1[] = {
+                /* batch0 */ 2.0f, 6.0f, 0.0f, 6.0f,
+                3.0f, 5.0f, 9.0f, 9.0f,
+                9.0f, 2.0f, 1.0f, 7.0f,
+                /* batch1 */ 6.0f, 8.0f, 4.0f, 7.0f,
+                6.0f, 5.0f, 4.0f, 9.0f,
+                5.0f, 7.0f, 3.0f, 8.0f,
+            };
+
+            TensorShape s2_shape = {2, 4, 5};
+            float d2[] = {
+                /* batch0 */ 0.0f, 8.0f, 9.0f, 3.0f, 7.0f,
+                3.0f, 8.0f, 5.0f, 5.0f, 4.0f,
+                3.0f, 0.0f, 8.0f, 4.0f, 0.0f,
+                7.0f, 3.0f, 4.0f, 9.0f, 4.0f,
+                /* batch1 */ 8.0f, 3.0f, 2.0f, 1.0f, 6.0f,
+                7.0f, 5.0f, 0.0f, 9.0f, 3.0f,
+                1.0f, 3.0f, 4.0f, 4.0f, 1.0f,
+                1.0f, 9.0f, 5.0f, 0.0f, 5.0f,
+            };
+
+            TensorShape exp_shape = {2, 3, 5};
+            float exp_d[] = {
+                /* batch0 */ 60.0f, 82.0f, 72.0f, 90.0f, 62.0f,
+                105.0f, 91.0f, 160.0f, 151.0f, 77.0f,
+                58.0f, 109.0f, 127.0f, 104.0f, 99.0f,
+                /* batch1 */ 115.0f, 133.0f, 63.0f, 94.0f, 99.0f,
+                96.0f, 136.0f, 73.0f, 67.0f, 100.0f,
+                100.0f, 131.0f, 62.0f, 80.0f, 94.0f,
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 5, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Batch of identity matrices — result should equal second operand
+        // s1: {3,2,2} (3 identity matrices), s2: {3,2,2}
+        {
+            TensorShape s1_shape = {3, 2, 2};
+            float d1[] = {
+                /* batch0 */ 1.0f, 0.0f, 0.0f, 1.0f,
+                /* batch1 */ 1.0f, 0.0f, 0.0f, 1.0f,
+                /* batch2 */ 1.0f, 0.0f, 0.0f, 1.0f,
+            };
+            TensorShape s2_shape = {3, 2, 2};
+            float d2[] = {
+                /* batch0 */ 1.0f, 2.0f, 3.0f, 4.0f,
+                /* batch1 */ 5.0f, 6.0f, 7.0f, 8.0f,
+                /* batch2 */ 9.0f, 10.0f, 11.0f, 12.0f,
+            };
+            TensorShape exp_shape = {3, 2, 2};
+            float exp_d[] = {
+                1.0f, 2.0f, 3.0f, 4.0f,
+                5.0f, 6.0f, 7.0f, 8.0f,
+                9.0f, 10.0f, 11.0f, 12.0f,
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 3: Rectangular per-batch multiply (2 batches): {2,1,3} @ {2,3,2} -> {2,1,2}
+        {
+            TensorShape s1_shape = {2, 1, 3};
+            float d1[] = {
+                /* batch0 */ 1.0f, 2.0f, 3.0f,  // row vector
+                /* batch1 */ 4.0f, 5.0f, 6.0f,  // row vector
+            };
+            TensorShape s2_shape = {2, 3, 2};
+            float d2[] = {
+                /* batch0 */ 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f,  // 3x2
+                /* batch1 */ 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f,  // reuse same matrix for simplicity
+            };
+            TensorShape exp_shape = {2, 1, 2};
+            float exp_d[] = {
+                /* batch0 */ 58.0f, 64.0f,  // [1,2,3] @ [[7,8],[9,10],[11,12]]
+                /* batch1 */ 139.0f, 154.0f, // [4,5,6] @ same
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 4: Batch of column-result matrices using ones to test reduction (4 batches): {4,2,3}@{4,3,1} -> {4,2,1}
+        {
+            TensorShape s1_shape = {4, 2, 3};
+            // each 2x3 filled with ones
+            float d1[4 * 2 * 3];
+            for(int i = 0; i < 4 * 2 * 3; ++i) d1[i] = 1.0f;
+            TensorShape s2_shape = {4, 3, 1};
+            // each 3x1 filled with ones
+            float d2[4 * 3 * 1];
+            for(int i = 0; i < 4 * 3 * 1; ++i) d2[i] = 1.0f;
+            TensorShape exp_shape = {4, 2, 1};
+            // each 2x1 entry will be sum of 3 ones = 3
+            float exp_d[4 * 2 * 1];
+            for(int i = 0; i < 4 * 2 * 1; ++i) exp_d[i] = 3.0f;
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 4, TEST_FLOAT_TOLERANCE);
+        }
+    }
 
     // Test Case 9: Special Matrix Content
     {
@@ -315,121 +439,276 @@ void test_matmul_operator() {
     // TODO: Problem in Matmul Broadcasting
 
     // // Test Case 10: Broadcasting
-    // {
-    //     const char* tc_name = "matmul_broadcasting";
+    {
+        const char* tc_name = "matmul_broadcasting";
 
-    //     // Sub-test 1: Simple matrix multiplication {4,5} @ {5,3} -> {4,3}
-    //     {
-    //         TensorShape s1_shape = {4, 5};
-    //         float d1[] = {
-    //             0.3745f, 0.9507f, 0.7320f, 0.5987f, 0.1560f,  // Row 0
-    //             0.1560f, 0.0581f, 0.8662f, 0.6011f, 0.7081f,  // Row 1
-    //             0.0206f, 0.9699f, 0.8324f, 0.2123f, 0.1818f,  // Row 2
-    //             0.1834f, 0.3042f, 0.5248f, 0.4319f, 0.2912f,  // Row 3
-    //         };
+        // Sub-test 1: Simple matrix multiplication {4,5} @ {5,3} -> {4,3}
+        {
+            TensorShape s1_shape = {4, 5};
+            float d1[] = {
+                0.3745f, 0.9507f, 0.7320f, 0.5987f, 0.1560f,  // Row 0
+                0.1560f, 0.0581f, 0.8662f, 0.6011f, 0.7081f,  // Row 1
+                0.0206f, 0.9699f, 0.8324f, 0.2123f, 0.1818f,  // Row 2
+                0.1834f, 0.3042f, 0.5248f, 0.4319f, 0.2912f,  // Row 3
+            };
 
-    //         TensorShape s2_shape = {5, 3};
-    //         float d2[] = {
-    //             0.6119f, 0.1395f, 0.2921f,  // Row 0
-    //             0.3664f, 0.4561f, 0.7852f,  // Row 1
-    //             0.1997f, 0.5142f, 0.5924f,  // Row 2
-    //             0.0465f, 0.6075f, 0.1705f,  // Row 3
-    //             0.0651f, 0.9489f, 0.9656f,  // Row 4
-    //         };
+            TensorShape s2_shape = {5, 3};
+            float d2[] = {
+                0.6119f, 0.1395f, 0.2921f,  // Row 0
+                0.3664f, 0.4561f, 0.7852f,  // Row 1
+                0.1997f, 0.5142f, 0.5924f,  // Row 2
+                0.0465f, 0.6075f, 0.1705f,  // Row 3
+                0.0651f, 0.9489f, 0.9656f,  // Row 4
+            };
 
-    //         TensorShape exp_shape = {4, 3};
-    //         float exp_d[] = {
-    //             0.7616f, 1.3740f, 1.5423f,  // Row 0
-    //             0.3637f, 1.5308f, 1.3906f,  // Row 1
-    //             0.5558f, 1.1748f, 1.4725f,  // Row 2
-    //             0.3675f, 0.9730f, 0.9582f,  // Row 3
-    //         };
+            TensorShape exp_shape = {4, 3};
+            float exp_d[] = {
+                0.7616f, 1.3740f, 1.5423f,  // Row 0
+                0.3637f, 1.5308f, 1.3906f,  // Row 1
+                0.5558f, 1.1748f, 1.4725f,  // Row 2
+                0.3675f, 0.9730f, 0.9582f,  // Row 3
+            };
 
-    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
-    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
-    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
-    //         Tensor actual_res = Tensor_matmul(t1, t2);
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
 
-    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1,
-    //         TEST_FLOAT_TOLERANCE);
-    //     }
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
 
-    //     // Sub-test 2: 3D Broadcasting {1,3,2} @ {2,2,4} -> {2,3,4}
-    //     {
-    //         TensorShape s1_shape = {1, 3, 2};
-    //         float d1[] = {
-    //             0.8084f, 0.3046f,  // [0,0,:]
-    //             0.0977f, 0.6842f,  // [0,1,:]
-    //             0.4402f, 0.1220f,  // [0,2,:]
-    //         };
+        // Sub-test 2: 3D Broadcasting {1,3,2} @ {2,2,4} -> {2,3,4}
+        {
+            TensorShape s1_shape = {1, 3, 2};
+            float d1[] = {
+                0.8084f, 0.3046f,
+                0.0977f, 0.6842f,
+                0.4402f, 0.1220f,
+            };
 
-    //         TensorShape s2_shape = {2, 2, 4};
-    //         float d2[] = {
-    //             // Batch 0
-    //             0.4952f, 0.0344f, 0.9093f, 0.2588f,  // [0,0,:]
-    //             0.6625f, 0.3117f, 0.5201f, 0.5467f,  // [0,1,:]
-    //             // Batch 1
-    //             0.1849f, 0.9696f, 0.7751f, 0.9395f,  // [1,0,:]
-    //             0.8948f, 0.5979f, 0.9219f, 0.0885f,  // [1,1,:]
-    //         };
+            TensorShape s2_shape = {2, 2, 4};
+            float d2[] = {
+                0.4952f, 0.0344f, 0.9093f, 0.2588f,
+                0.6625f, 0.3117f, 0.5201f, 0.5467f,
+                
+                0.1849f, 0.9696f, 0.7751f, 0.9395f,
+                0.8948f, 0.5979f, 0.9219f, 0.0885f,
+            };
 
-    //         TensorShape exp_shape = {2, 3, 4};
-    //         float exp_d[] = {
-    //             // Batch 0
-    //             0.6021f, 0.1228f, 0.8935f, 0.3757f,  // [0,0,:]
-    //             0.5017f, 0.2166f, 0.4447f, 0.3994f,  // [0,1,:]
-    //             0.2988f, 0.0532f, 0.4637f, 0.1806f,  // [0,2,:]
-    //             // Batch 1
-    //             0.4220f, 0.9659f, 0.9074f, 0.7864f,  // [1,0,:]
-    //             0.6303f, 0.5038f, 0.7065f, 0.1523f,  // [1,1,:]
-    //             0.1906f, 0.4997f, 0.4537f, 0.4243f,  // [1,2,:]
-    //         };
+            TensorShape exp_shape = {2, 3, 4};
+            float exp_d[] = {
+                0.6021f, 0.1228f, 0.8935f, 0.3757f,
+                0.5017f, 0.2166f, 0.4447f, 0.3994f,
+                0.2988f, 0.0532f, 0.4637f, 0.1806f,
+                
+                0.4220f, 0.9659f, 0.9074f, 0.7864f,
+                0.6303f, 0.5038f, 0.7065f, 0.1523f,
+                0.1906f, 0.4997f, 0.4537f, 0.4243f,
+            };
 
-    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
-    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
-    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
-    //         Tensor actual_res = Tensor_matmul(t1, t2);
-    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2,
-    //         TEST_FLOAT_TOLERANCE);
-    //     }
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+            
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
 
-    //     // Sub-test 3: 4D Broadcasting {2,1,2,3} @ {1,1,3,2} -> {2,1,2,2}
-    //     {
-    //         TensorShape s1_shape = {2, 1, 2, 3};
-    //         float d1[] = {
-    //             // Batch 0
-    //             0.1960f, 0.0452f, 0.3253f,  // [0,0,0,:]
-    //             0.3887f, 0.2713f, 0.8287f,  // [0,0,1,:]
-    //             // Batch 1
-    //             0.3568f, 0.2809f, 0.5427f,  // [1,0,0,:]
-    //             0.1409f, 0.8022f, 0.0746f,  // [1,0,1,:]
-    //         };
+        // Sub-test 3: 4D Broadcasting {2,1,2,3} @ {1,1,3,2} -> {2,1,2,2}
+        {
+            TensorShape s1_shape = {2, 1, 2, 3};
+            float d1[] = {
+                0.1960f, 0.0452f, 0.3253f,
+                0.3887f, 0.2713f, 0.8287f,
+                
+                0.3568f, 0.2809f, 0.5427f,
+                0.1409f, 0.8022f, 0.0746f,
+            };
 
-    //         TensorShape s2_shape = {1, 1, 3, 2};
-    //         float d2[] = {
-    //             0.9869f, 0.7722f,  // [0,0,0,:]
-    //             0.1987f, 0.0055f,  // [0,0,1,:]
-    //             0.8155f, 0.7069f,  // [0,0,2,:]
-    //         };
+            TensorShape s2_shape = {1, 1, 3, 2};
+            float d2[] = {
+                0.9869f, 0.7722f,
+                0.1987f, 0.0055f,
+                0.8155f, 0.7069f,
+            };
 
-    //         TensorShape exp_shape = {2, 1, 2, 2};
-    //         float exp_d[] = {
-    //             // Batch 0
-    //             0.4677f, 0.3816f,  // [0,0,0,:]
-    //             1.1133f, 0.8875f,  // [0,0,1,:]
-    //             // Batch 1
-    //             0.8504f, 0.6607f,  // [1,0,0,:]
-    //             0.3593f, 0.1660f,  // [1,0,1,:]
-    //         };
+            TensorShape exp_shape = {2, 1, 2, 2};
+            float exp_d[] = {
+                0.4677f, 0.3816f,
+                1.1133f, 0.8875f,
+                
+                0.8504f, 0.6607f,
+                0.3593f, 0.1660f,
+            };
 
-    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
-    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
-    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
-    //         Tensor actual_res = Tensor_matmul(t1, t2);
-    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 3,
-    //         TEST_FLOAT_TOLERANCE);
-    //     }
-    // }
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+            
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 4: 3D × 3D Broadcasting {2,1,3} @ {1,3,2} -> {2,1,2}
+        {
+            TensorShape s1_shape = {2, 1, 3};
+            float d1[] = {
+                1.0f, 2.0f, 3.0f,
+
+                4.0f, 5.0f, 6.0f,
+            };
+
+            TensorShape s2_shape = {1, 3, 2};
+            float d2[] = {
+                1.0f, 2.0f,
+                3.0f, 4.0f,
+                5.0f, 6.0f,
+            };
+
+            TensorShape exp_shape = {2, 1, 2};
+            float exp_d[] = {
+                22.0f, 28.0f,
+                
+                49.0f, 64.0f,
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 4, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 5: 3D × 4D Broadcasting {1,2,3} @ {2,1,3,2} -> {2,1,2,2}
+        {
+            TensorShape s1_shape = {1, 2, 3};
+            float d1[] = {
+                1.0f, 2.0f, 3.0f,
+                4.0f, 5.0f, 6.0f,
+            };
+
+            TensorShape s2_shape = {2, 1, 3, 2};
+            float d2[] = {
+                1.0f, 0.0f,
+                0.0f, 1.0f,
+                1.0f, 1.0f,
+                
+                2.0f, 1.0f,
+                1.0f, 2.0f,
+                0.0f, 1.0f,
+            };
+
+            TensorShape exp_shape = {2, 1, 2, 2};
+            float exp_d[] = {
+                4.0f, 5.0f,
+                10.0f, 11.0f,
+                
+                5.0f, 8.0f,
+                14.0f, 20.0f,
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 5, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 6: 4D × 4D Broadcasting {1,2,2,3} @ {2,1,3,2} -> {2,2,2,2}
+        {
+            TensorShape s1_shape = {1, 2, 2, 3};
+            float d1[] = {
+                1.0f, 0.0f, 1.0f,
+                0.0f, 1.0f, 1.0f,
+
+                2.0f, 1.0f, 0.0f,
+                1.0f, 2.0f, 1.0f,
+            };
+
+            TensorShape s2_shape = {2, 1, 3, 2};
+            float d2[] = {
+                1.0f, 1.0f,
+                1.0f, 0.0f,
+                0.0f, 1.0f,
+                
+                0.0f, 1.0f,
+                1.0f, 1.0f,
+                1.0f, 0.0f,
+            };
+
+            TensorShape exp_shape = {2, 2, 2, 2};
+            float exp_d[] = {
+                1.0f, 2.0f,
+                1.0f, 1.0f,
+                
+                2.0f, 2.0f,
+                3.0f, 2.0f,
+                
+                1.0f, 1.0f,
+                2.0f, 1.0f,
+                
+                0.0f, 2.0f,
+                1.0f, 3.0f,
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 6, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 7: 4D × 3D Broadcasting {2,2,2,3} @ {1,3,4} -> {2,2,2,4}
+        {
+            TensorShape s1_shape = {2, 2, 2, 3};
+            float d1[] = {
+                1.0f, 0.0f, 0.0f,
+                0.0f, 1.0f, 0.0f,
+                
+                0.0f, 0.0f, 1.0f,
+                1.0f, 1.0f, 1.0f,
+                
+                2.0f, 0.0f, 0.0f,
+                0.0f, 2.0f, 0.0f,
+                
+                0.0f, 0.0f, 2.0f,
+                1.0f, 1.0f, 1.0f,
+            };
+
+            TensorShape s2_shape = {1, 3, 4};
+            float d2[] = {
+                1.0f, 2.0f, 3.0f, 4.0f,
+                5.0f, 6.0f, 7.0f, 8.0f,
+                9.0f, 10.0f, 11.0f, 12.0f,
+            };
+
+            TensorShape exp_shape = {2, 2, 2, 4};
+            float exp_d[] = {
+                1.0f, 2.0f, 3.0f, 4.0f,
+                5.0f, 6.0f, 7.0f, 8.0f,
+                
+                9.0f, 10.0f, 11.0f, 12.0f,
+                15.0f, 18.0f, 21.0f, 24.0f,
+                
+                
+                2.0f, 4.0f, 6.0f, 8.0f,
+                10.0f, 12.0f, 14.0f, 16.0f, 
+                
+                18.0f, 20.0f, 22.0f, 24.0f,
+                15.0f, 18.0f, 21.0f, 24.0f,
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 7, TEST_FLOAT_TOLERANCE);
+        }
+    }
 
     cten_free(pool_id);
 }


### PR DESCRIPTION
### Broadcasting Implementation for Matrix Multiplication

The cTensor library has been enhanced with extensive _broadcasting_ support for matrix multiplication operations, bringing it closer to the functionality offered by major tensor libraries like **PyTorch** and **NumPy**. This advancement significantly improves the library's flexibility by allowing matrix operations between tensors of different but compatible shapes.

# Comprehensive Test Coverage Added

The test suite now includes thorough validation for various broadcasting scenarios:

- **4D × 4D Broadcasting**: Tests matrix multiplication between 4-dimensional tensors with different shapes that are broadcastable, such as `{1,2,2,3} @ {2,1,3,2} -> {2,2,2,2}`

- **3D × 4D Broadcasting**: Validates operations between 3D and 4D tensors, like `{1,2,3} @ {2,1,3,2} -> {2,1,2,2}`, ensuring proper dimension expansion and contraction

- **3D × 3D Broadcasting**: Covers scenarios such as `{2,1,3} @ {1,3,2} -> {2,1,2}` where broadcasting occurs across batch dimensions

The test cases verify that:
- Simple 2D matrix operations continue to work correctly
- Batch matrix operations maintain their expected behavior
- Complex multi-dimensional broadcasting follows standard tensor algebra rules
- Edge cases with identity matrices and special content (zeros, ones) produce correct results

This implementation ensures that existing functionality remains intact while adding powerful new capabilities for handling tensors with mismatched but compatible dimensions, making cTensor more versatile for real-world applications requiring flexible tensor operations.